### PR TITLE
Issue#62_Search Fixes

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -246,3 +246,7 @@ h1 {
   display: inline-block;
   border-radius: 50%;
 }
+
+#hidden{
+  display: none
+}

--- a/views/layout.html
+++ b/views/layout.html
@@ -26,6 +26,28 @@
           <li><a href="/contact">Contact</a></li>
           <li><a href="https://github.com/FrancescoSTL/Site-Sonar"><b>Download</b></a></li>
         </ul>
+        <div class="col-sm-3 col-md-3 pull-right">
+          <form class="navbar-form" role="search" method="get" action="/search">
+            <div class="input-group">
+              <input type="text" class="form-control" placeholder="Search" name="query" id="srch-term">
+              <div class="input-group-btn">
+                <button class="btn btn-default" type="submit"><i class="fa fa-search" aria-hidden="true"></i></button>
+              </div>
+            </div>
+            <div class="input-group" id="hidden">
+              <div class="radio">
+                <label>
+                  <input type="radio" name="searchBy" value="adNetwork" checked> Networks
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  <input type="radio" name="searchBy" value="originUrl"> Sites 
+                </label>
+              </div>
+            </div>
+          </form>
+        </div>
       </div><!--/.nav-collapse -->
     </nav>
 
@@ -48,6 +70,9 @@
 
     </div> <!-- /container -->
 
+
+    <script src="https://use.fontawesome.com/383724b71c.js"></script>
+
     <!-- jquery -->
     <script
       src="http://code.jquery.com/jquery-3.1.0.min.js"
@@ -65,7 +90,14 @@
       ga('create', 'UA-82101385-1', 'auto');
       ga('send', 'pageview');
     </script>
-
+    <!-- If page is /search, enable radio buttons-->
+    <script>
+      var page = window.location.href;
+      if (page.includes("search")) {
+        var div = document.getElementById("hidden");
+        div.style.display = 'block';
+      }
+    </script>
     {% block scripts %}
     {% endblock %}
   </body>

--- a/views/networkstats.html
+++ b/views/networkstats.html
@@ -60,9 +60,6 @@
 
 {% block scripts %}
 <script>
-  $('#networks-by-file-size').addClass('active');
-
-
 
   var fileSizes = [], loadTimes = [];
 

--- a/views/search.html
+++ b/views/search.html
@@ -1,0 +1,41 @@
+{% extends "layout.html" %}
+
+{% block body %}
+<div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+    <h2 class="sub-header">Search results</h2>
+    {% if searchResults | length == 0%}
+    <p>No search results for : {{searchTerm}}.</p>
+    {% else %}
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+            <tr>
+
+                {% if category == "adNetwork" %}
+                <th>Network</th>
+                {% else %}
+                <th>Web Site</th>
+                {% endif %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for record in searchResults %}
+            <tr>
+                {% if category == "adNetwork" %}
+                <td><a href="/networkstats?network={{record._id}}">{{record._id}}</a></td>
+                {% else %}
+                <td><a href="/sitestats?site={{record._id}}">{{record._id}}</a></td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+</script>
+{% endblock %}


### PR DESCRIPTION
Fixes #62.
- Dev version [here](http://dev-site-sonar.herokuapp.com/networksbyloadtime)
- Search enabled in sitesby and networksby pages. 
- Search is conducted on either networks or sites based on which site you hit search from. 
- If you search from `/sitesbyloadtime`, results are websites, and vice versa.

⚠️ Don't merge yet 👇 👇 ⚠️ 
### Known Bug : To be Fixed
- networkstats and sitestats endpoints don't work 😞 
- searching from `/search` page searches by sites. Dunno what to do here - remove search bar or give another search bar with two buttons - **Search By Network** and **Search by Sites**
